### PR TITLE
Add missing XFSC components into TOPICS list

### DIFF
--- a/scripts/navigation.py
+++ b/scripts/navigation.py
@@ -4,7 +4,7 @@ import os
 GITHUB_ORG = os.getenv("GITHUB_ORG")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
-TOPICS = ["tsa", "ocm-w-stack", "ocm","aas","orchestration","cam","catalogue","portal","notarization","pcm-mobile","pcm-cloud", "facis"]
+TOPICS = ["aas","ocm", "ocm-w-stack", "pcm-mobile","pcm-cloud","tsa", "train", "notarization", "catalogue","self-description","data-contract","data-exchange","orchestration","cam","portal","facis"]
 
 README_PATH = "README.md"
 INSERT_ANCHOR = "# XFSC Navigation"


### PR DESCRIPTION
As comparing the website "https://projects.eclipse.org/projects/technology.xfsc", some of the components were missing in the overview, which has been added to it.